### PR TITLE
Go enhancements

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -115,7 +115,7 @@ function convert.protocol(all, obj, namespace)
 	local result = { tag = obj[2], meta=obj.meta, name = obj[1]}
 	local ex = namespace and namespace.."." or ""
 
-	for _, p in ipairs(obj[3]) do
+	for order, p in ipairs(obj[3]) do
 		local pt = p[1]
 		if result[pt] ~= nil then
 			local meta_info = tostring(result.meta)
@@ -127,8 +127,9 @@ function convert.protocol(all, obj, namespace)
 		local tt = type(typename)
 		if tt == "table" then
 			local struct = typename
+			local meta = {file=obj.meta.file, line=obj.meta.line, order=order}
 			typename = obj[1] .. "." .. p[1]
-			all.type[typename] = convert.type(all, { typename, struct })
+			all.type[typename] = convert.type(all, { typename, struct, meta=meta })
 		elseif tt == "string" then
 			local test_name = ex..typename
 			typename = all.type[test_name] and test_name or typename
@@ -197,6 +198,7 @@ function convert.type(all, obj)
 		end
 	end
 	table.sort(result, function(a,b) return a.tag < b.tag end)
+	result.meta = obj.meta
 	return result
 end
 

--- a/sprotodump.lua
+++ b/sprotodump.lua
@@ -8,17 +8,17 @@ sprotodump is a simple tool to convert sproto file to spb binary.
 
 usage: lua sprotodump.lua <option> <sproto_file1 sproto_file2 ...> [[<out_option> <outfile>] ...] [namespace_option]
 
-    option: 
+    option:
         -cs              dump to cSharp code file
         -spb             dump to binary spb  file
         -go              dump to go code file
         -md              dump to markdown file
         -lua             dump to lua table
-        
+
     out_option:
         -d <dircetory>               dump to speciffic dircetory
         -o <file>                    dump to speciffic file
-        -p <package name>            set package name(only cSharp code use)
+        -p <package name>            set package name(only cSharp and go code use)
 
     namespace_option:
         -namespace       add namespace to type and protocol


### PR DESCRIPTION
1. 支持binary、double、map类型；示例见[sproto_types](https://github.com/xjdrew/gosproto/tree/44e09992b6c890d2c47563c157afa2505b1c3666/examples/sproto_types) 目录
2. 以.sproto文件定义的顺序生成代码